### PR TITLE
[#18] OAuth 기능을 구현했습니다.

### DIFF
--- a/BE/baseball/build.gradle
+++ b/BE/baseball/build.gradle
@@ -31,6 +31,11 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.1',
+            // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
+            // 'org.bouncycastle:bcprov-jdk15on:1.60',
+            'io.jsonwebtoken:jjwt-jackson:0.11.1' // or 'io.jsonwebtoken:jjwt-gson:0.11.1' for gson
 }
 
 test {

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
@@ -1,0 +1,15 @@
+package kr.codesquad.baseball.business.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@ToString
+@Getter
+public class User {
+
+    private final String id;
+    private final String nickname;
+    private final String email;
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-@RequiredArgsConstructor
-@ToString
 @Getter
+@ToString
+@RequiredArgsConstructor
 public class User {
 
     private final String id;

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/User.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.util.Map;
+
 @Getter
 @ToString
 @RequiredArgsConstructor
@@ -12,4 +14,14 @@ public class User {
     private final String id;
     private final String nickname;
     private final String email;
+
+    public static User of(Map<String, String> userMap) {
+        return new User(userMap);
+    }
+
+    private User(Map<String, String> userMap) {
+        this.id = userMap.get("id");
+        this.nickname = userMap.get("nickname");
+        this.email = userMap.get("email");
+    }
 }

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/UserDAO.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/business/domain/user/UserDAO.java
@@ -1,0 +1,9 @@
+package kr.codesquad.baseball.business.domain.user;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class UserDAO {
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/RestTemplateConfig.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package kr.codesquad.baseball.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/SpringFoxConfig.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/SpringFoxConfig.java
@@ -8,9 +8,10 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-@Configuration
 @EnableSwagger2
+@Configuration
 public class SpringFoxConfig {
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/WebConfig.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/config/WebConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/error/GlobalRestExceptionHandler.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/error/GlobalRestExceptionHandler.java
@@ -1,8 +1,7 @@
 package kr.codesquad.baseball.common.error;
 
 import kr.codesquad.baseball.common.error.exception.BusinessException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -10,9 +9,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalRestExceptionHandler {
-    private static final Logger log = LoggerFactory.getLogger(GlobalRestExceptionHandler.class);
 
     /**
      * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
@@ -12,8 +12,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-@Service
 @Slf4j
+@Service
 public class GitHubOAuthService {
 
     private static final String GITHUB_USER_API_URL = "https://api.github.com/user";

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
@@ -1,0 +1,67 @@
+package kr.codesquad.baseball.common.oauth.github;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.codesquad.baseball.business.domain.user.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class GitHubOAuthService {
+
+    private static final String GITHUB_USER_API_URL = "https://api.github.com/user";
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    public GitHubOAuthService(ObjectMapper objectMapper, RestTemplate restTemplate) {
+        this.objectMapper = objectMapper;
+        this.restTemplate = restTemplate;
+    }
+
+    public GitHubToken getGitHubTokenToCode(String code) {
+        HttpEntity<GitHubRequestPayload> request = new HttpEntity<>(GitHubRequestPayload.valueOf(code));
+        String accessTokenUrl = "https://github.com/login/oauth/access_token";
+        return restTemplate.postForEntity(accessTokenUrl, request, GitHubToken.class).getBody();
+    }
+
+    // TODO: 유저정보 저장용 DB 설계하고 저장하기
+    public User insertUserInfo(String token) {
+        return getGitHubUserInfoToToken(token).transformToUser();
+    }
+
+    public GitHubUser getGitHubUserInfoToToken(String token) {
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set("Authorization", "token " + token);
+        GitHubUser user = restTemplate.exchange(GITHUB_USER_API_URL, HttpMethod.GET, new HttpEntity<>(requestHeaders), GitHubUser.class).getBody();
+
+        if (user.getEmail() == null) {
+            user.setEmail(getEmailFromGitHub(requestHeaders));
+        }
+
+        return user;
+    }
+
+    @Nullable
+    public String getEmailFromGitHub(HttpHeaders requestHeaders) {
+        String email = restTemplate.exchange(GITHUB_USER_API_URL + "/emails", HttpMethod.GET, new HttpEntity<>(requestHeaders), String.class).getBody();
+
+        try {
+            JsonNode emailNode = objectMapper.readTree(email);
+            for (JsonNode jsonNode : emailNode) {
+                if (jsonNode.get("primary").asBoolean()) {
+                    return jsonNode.get("email").textValue();
+                }
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Json 형식이 잘못되었어요.", e);
+        }
+        return null;
+    }
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubOAuthService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.codesquad.baseball.business.domain.user.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -13,17 +14,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class GitHubOAuthService {
 
     private static final String GITHUB_USER_API_URL = "https://api.github.com/user";
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
-
-    public GitHubOAuthService(ObjectMapper objectMapper, RestTemplate restTemplate) {
-        this.objectMapper = objectMapper;
-        this.restTemplate = restTemplate;
-    }
 
     public GitHubToken getGitHubTokenToCode(String code) {
         HttpEntity<GitHubRequestPayload> request = new HttpEntity<>(GitHubRequestPayload.valueOf(code));

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubRequestPayload.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubRequestPayload.java
@@ -1,0 +1,27 @@
+package kr.codesquad.baseball.common.oauth.github;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class GitHubRequestPayload {
+
+    @JsonProperty("client_id")
+    private final String clientId = System.getenv("GITHUB_CLIENT_ID");
+
+    @JsonProperty("client_secret")
+    private final String clientSecret = System.getenv("GITHUB_CLIENT_SECRET");
+
+    private final String code;
+
+    private GitHubRequestPayload(String code) {
+        this.code = code;
+    }
+
+    public static GitHubRequestPayload valueOf(String code) {
+        return new GitHubRequestPayload(code);
+    }
+
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubToken.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubToken.java
@@ -1,0 +1,19 @@
+package kr.codesquad.baseball.common.oauth.github;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GitHubToken {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubUser.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/oauth/github/GitHubUser.java
@@ -1,0 +1,18 @@
+package kr.codesquad.baseball.common.oauth.github;
+
+import kr.codesquad.baseball.business.domain.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GitHubUser {
+
+    private String login;
+    private String name;
+    private String email;
+
+    public User transformToUser() {
+        return new User(this.login, this.name, this.email);
+    }
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
@@ -1,0 +1,62 @@
+package kr.codesquad.baseball.common.util;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import kr.codesquad.baseball.common.error.exception.LoginRequiredException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class JwtService {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtService.class);
+    private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    public String createJws(String jwtKey, Object data) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "JWT");
+        headers.put("alg", "HS256");
+
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.put(jwtKey, data);
+
+        return Jwts.builder()
+                   .setHeader(headers)
+                   .setClaims(payloads)
+                   .signWith(key)
+                   .compact();
+    }
+
+    public String createJws(Map<String, Object> payloads) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "JWT");
+        headers.put("alg", "HS256");
+
+        return Jwts.builder()
+                   .setHeader(headers)
+                   .setClaims(payloads)
+                   .signWith(key)
+                   .compact();
+    }
+
+    public Map<String, Object> getDataFromJws(String jws, String jwtKey) {
+        Jws<Claims> claims;
+        try {
+            claims = Jwts.parserBuilder()
+                         .setSigningKey(key)
+                         .build()
+                         .parseClaimsJws(jws);
+            return (LinkedHashMap<String, Object>) claims.getBody().get(jwtKey);
+        } catch (JwtException ex) {
+            log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
+            // Custom Exception Unauthorized Exception
+            throw new LoginRequiredException("인증되지 않은 jwt token입니다.");
+        }
+    }
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
@@ -2,6 +2,7 @@ package kr.codesquad.baseball.common.util;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import kr.codesquad.baseball.business.domain.user.User;
 import kr.codesquad.baseball.common.error.exception.LoginRequiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.Map;
 public class JwtService {
 
     private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private static final String USER_JWT_KEY = "user";
 
     public String createJws(String jwtKey, Object data) {
         Map<String, Object> headers = new HashMap<>();
@@ -44,6 +46,21 @@ public class JwtService {
                    .compact();
     }
 
+    public String createUserJws(User data) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "JWT");
+        headers.put("alg", "HS256");
+
+        Map<String, User> payloads = new HashMap<>();
+        payloads.put(USER_JWT_KEY, data);
+
+        return Jwts.builder()
+                   .setHeader(headers)
+                   .setClaims(payloads)
+                   .signWith(key)
+                   .compact();
+    }
+
     public Map<String, Object> getDataFromJws(String jwtKey, String jws) {
         Jws<Claims> claims;
         try {
@@ -52,6 +69,21 @@ public class JwtService {
                          .build()
                          .parseClaimsJws(jws);
             return (LinkedHashMap<String, Object>) claims.getBody().get(jwtKey);
+        } catch (JwtException ex) {
+            log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
+            // Custom Exception Unauthorized Exception
+            throw new LoginRequiredException("인증되지 않은 jwt token입니다.");
+        }
+    }
+
+    public User getUserFromJws(String jws) {
+        Jws<Claims> claims;
+        try {
+            claims = Jwts.parserBuilder()
+                         .setSigningKey(key)
+                         .build()
+                         .parseClaimsJws(jws);
+            return User.of((LinkedHashMap<String, String>) claims.getBody().get(USER_JWT_KEY));
         } catch (JwtException ex) {
             log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
             // Custom Exception Unauthorized Exception

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
@@ -45,7 +45,7 @@ public class JwtService {
                    .compact();
     }
 
-    public Map<String, Object> getDataFromJws(String jws, String jwtKey) {
+    public Map<String, Object> getDataFromJws(String jwtKey, String jws) {
         Jws<Claims> claims;
         try {
             claims = Jwts.parserBuilder()

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/common/util/JwtService.java
@@ -3,8 +3,7 @@ package kr.codesquad.baseball.common.util;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import kr.codesquad.baseball.common.error.exception.LoginRequiredException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
@@ -12,10 +11,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Slf4j
 @Service
 public class JwtService {
 
-    private static final Logger log = LoggerFactory.getLogger(JwtService.class);
     private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
     public String createJws(String jwtKey, Object data) {

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
@@ -5,6 +5,7 @@ import kr.codesquad.baseball.common.oauth.github.GitHubOAuthService;
 import kr.codesquad.baseball.common.util.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ public class LoginController {
     public ResponseEntity<String> loginWithGithub(@CookieValue(value = "jwt", required = false) String jwt) {
         if (jwt != null) {
             log.debug("jwt 토큰 값: {}", jwt);
-            log.debug("jwt에 저장된 값: {}", jwtService.getDataFromJws("user", jwt));
+            log.debug("jwt에 저장된 값: {}", jwtService.getUserFromJws(jwt));
             return ResponseEntity.ok("ok");
         }
 
@@ -51,7 +52,7 @@ public class LoginController {
         User user = gitHubOAuthService.insertUserInfo(accessToken);
         log.debug("DB에 저장된 User 정보: {}", user);
 
-        String jws = jwtService.createJws("user", user);
+        String jws = jwtService.createUserJws(user);
         log.debug("jws: {}", jws);
 
         Cookie cookie = new Cookie("jwt", jws);

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
@@ -1,0 +1,71 @@
+package kr.codesquad.baseball.web.controller;
+
+import kr.codesquad.baseball.business.domain.user.User;
+import kr.codesquad.baseball.common.oauth.github.GitHubOAuthService;
+import kr.codesquad.baseball.common.util.JwtService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URI;
+
+@RestController
+@Slf4j
+public class LoginController {
+
+    private final GitHubOAuthService gitHubOAuthService;
+    private final JwtService jwtService;
+
+    public LoginController(GitHubOAuthService gitHubOAuthService, JwtService jwtService) {
+        this.gitHubOAuthService = gitHubOAuthService;
+        this.jwtService = jwtService;
+    }
+
+    // TODO: Post로 변경
+    @GetMapping("/login/with-github")
+    public ResponseEntity<String> loginWithGithub(@CookieValue(value = "jwt", required = false) String jwt) {
+        if (jwt != null) {
+            log.debug("jwt 토큰 값: {}", jwt);
+            log.debug("jwt에 저장된 값: {}", jwtService.getDataFromJws("user", jwt));
+            return new ResponseEntity<>("ok", HttpStatus.OK);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        URI uri = UriComponentsBuilder.fromUriString("https://github.com/login/oauth/authorize")
+                                      .queryParam("client_id", System.getenv("GITHUB_CLIENT_ID"))
+                                      .queryParam("scope", "user")
+                                      .build()
+                                      .toUri();
+        headers.setLocation(uri);
+        return new ResponseEntity<>("redirect", headers, HttpStatus.SEE_OTHER);
+    }
+
+    @GetMapping("/oauth")
+    public ResponseEntity<String> oauthAuthentication(@RequestParam("code") String code, HttpServletResponse response) {
+        String accessToken = gitHubOAuthService.getGitHubTokenToCode(code).getAccessToken();
+        log.debug("AccessToken: {}", accessToken);
+
+        User user = gitHubOAuthService.insertUserInfo(accessToken);
+        log.debug("DB에 저장된 User 정보: {}", user);
+
+        String jws = jwtService.createJws("user", user);
+        log.debug("jws: {}", jws);
+
+        Cookie cookie = new Cookie("jwt", jws);
+        cookie.setMaxAge(7 * 24 * 60 * 60); // expires in 7 days
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setHeader("Location", "http://localhost:8080/login/with-github");
+        return new ResponseEntity<>("redirect", HttpStatus.FOUND);
+    }
+
+}

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
@@ -32,7 +32,7 @@ public class LoginController {
         if (jwt != null) {
             log.debug("jwt 토큰 값: {}", jwt);
             log.debug("jwt에 저장된 값: {}", jwtService.getDataFromJws("user", jwt));
-            return new ResponseEntity<>("ok", HttpStatus.OK);
+            return ResponseEntity.ok("ok");
         }
 
         HttpHeaders headers = new HttpHeaders();

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
@@ -8,10 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.Cookie;
@@ -20,6 +17,7 @@ import java.net.URI;
 
 @Slf4j
 @RequiredArgsConstructor
+@RequestMapping("/login")
 @RestController
 public class LoginController {
 
@@ -27,7 +25,7 @@ public class LoginController {
     private final JwtService jwtService;
 
     // TODO: Post로 변경
-    @GetMapping("/login/with-github")
+    @GetMapping("/with-github")
     public ResponseEntity<String> loginWithGithub(@CookieValue(value = "jwt", required = false) String jwt) {
         if (jwt != null) {
             log.debug("jwt 토큰 값: {}", jwt);

--- a/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
+++ b/BE/baseball/src/main/java/kr/codesquad/baseball/web/controller/LoginController.java
@@ -3,6 +3,7 @@ package kr.codesquad.baseball.web.controller;
 import kr.codesquad.baseball.business.domain.user.User;
 import kr.codesquad.baseball.common.oauth.github.GitHubOAuthService;
 import kr.codesquad.baseball.common.util.JwtService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -17,17 +18,13 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 
-@RestController
 @Slf4j
+@RequiredArgsConstructor
+@RestController
 public class LoginController {
 
     private final GitHubOAuthService gitHubOAuthService;
     private final JwtService jwtService;
-
-    public LoginController(GitHubOAuthService gitHubOAuthService, JwtService jwtService) {
-        this.gitHubOAuthService = gitHubOAuthService;
-        this.jwtService = jwtService;
-    }
 
     // TODO: Post로 변경
     @GetMapping("/login/with-github")


### PR DESCRIPTION
### OAuth 로그인 기능

- package 구조를 변경했습니다.
- JWT Token을 생성하고 검증하는 JwtService를 Bean 등록하였습니다.
- RestTemplate을 자주 사용해서 Bean 등록하였습니다.
- GitHub OAuth 관련 객체를 생성하였습니다.
  - RequestPayload는 깃헙에 token을 발급받기 위해 사용하는 클래스입니다.
  - GitHubToken은 깃헙에서 주는 데이터를 Class로 받기 위한 클래스입니다.
  - GitHubUser는 깃헙에서 주는 정보를 바탕으로 User 객체를 만들기 위한 클래스입니다.
    GitHubUser 클래스는 DB에 직접적으로 넣지 않고, User 객체로 변환 후에 넣도록 설계했습니다.
  - User 클래스는 불변객체로 생성되게끔 하였습니다. 때문에, Setter 애노테이션은 없습니다.
- GitHub OAuth 관련 기능을 개발하였습니다.
  - LoginController에서는 깃헙 로그인 버튼을 클릭했다고 가정하고 개발하였습니다.
    지금은 GetMapping이지만, 최종적으로는 PostMapping이 될 것 입니다.

  흐름은 다음과 같습니다.
   - login 요청 ---> jwt 토큰이 있으면, 통과
    (이전에 인터셉터에서 정상 토큰인지 확인해서 401 응답을 주어야 합니다.)

   - jwt 토큰이 없다면 ---> GitHub으로 이동(미등록 유저의 경우 등록 절차를 거칩니다.)
    등록된 경우, CallBack Url에 code값을 담아서 요청이 오게됩니다.

   - code ---> GitHubToken 발급 ---> 발급 받은 Token으로 User정보 저장(이미 있으면 토큰만 갱신)
    ---> 저장된 User 정보를 jwt token으로 만들어서 쿠키에 저장

현재 미구현된 부분은 User 정보를 DB 저장하는 부분입니다.
이 부분은 DB 설계 후 DAO에 붙일 생각입니다.

대략의 시그니처는 count 쿼리를 사용해서 row의 개수로 존재 유무를 판단하고
Update와 Insert를 분기하면 될 것 같습니다.

감사합니다!